### PR TITLE
fix(validation): require explicit rig for witness and refinery agents

### DIFF
--- a/internal/validation/bead.go
+++ b/internal/validation/bead.go
@@ -233,11 +233,8 @@ func ValidateAgentID(id string) error {
 		if isTownLevelRole(role) {
 			return nil // Valid town-level agent (gt-mayor, gt-deacon)
 		}
-		// Support deduplicated format: <prefix>-<role> where prefix == rig
-		// This handles cases like "spa-witness" for spa rig with spa- prefix
-		// (Gas Town deduplicates to avoid "spa-spa-witness")
 		if isRigLevelRole(role) {
-			return nil // Valid deduplicated rig-level singleton
+			return fmt.Errorf("agent role %q requires rig: <prefix>-<rig>-%s (got %q)", role, role, id)
 		}
 		if isNamedRole(role) {
 			// Named roles still need a name even in deduplicated format


### PR DESCRIPTION
Previously, ValidateAgentID accepted deduplicated format for witness and refinery roles (e.g., "gt-witness"), but TestValidateAgentID expected these roles to always require an explicit rig name.

This change removes the deduplicated format support for rig-level roles, ensuring witness and refinery agent IDs must include an explicit rig: <prefix>-<rig>-witness or <prefix>-<rig>-refinery.

Fixes: bd-sp1t